### PR TITLE
Implement user timezone feature

### DIFF
--- a/USER_TIMEZONE_FEATURE.md
+++ b/USER_TIMEZONE_FEATURE.md
@@ -1,0 +1,73 @@
+# User Timezone Feature Implementation
+
+## Overview
+This document describes the implementation of the user timezone feature in AsyncStatus.
+
+## Changes Made
+
+### Database Schema
+1. **Added timezone field to user table** (`apps/api/src/db/schema.ts`)
+   - Field: `timezone` (text, default: "UTC")
+   - Stores IANA timezone identifiers (e.g., "America/New_York")
+
+2. **Generated migration** (`apps/api/drizzle/0001_natural_rumiko_fujikawa.sql`)
+   - SQL: `ALTER TABLE user ADD timezone text DEFAULT 'UTC';`
+
+### Backend API
+1. **Created user router** (`apps/api/src/routers/user.ts`)
+   - `GET /user/me` - Get current user profile with timezone
+   - `PATCH /user/me` - Update user profile including timezone
+   - `GET /user/timezones` - Get list of supported timezones
+
+2. **Created user schema** (`apps/api/src/schema/user.ts`)
+   - `zUserProfileUpdate` - Validation schema for profile updates
+
+3. **Updated main API router** (`apps/api/src/index.ts`)
+   - Added user router to the main app routes
+
+### Frontend UI
+1. **Created profile page** (`apps/web-app/src/routes/$organizationSlug/_layout.profile.tsx`)
+   - User can view and update their name, timezone, and profile image
+   - Includes a dropdown with common timezone options
+   - Form validation and error handling
+
+2. **Updated user menu** (`apps/web-app/src/components/user-menu.tsx`)
+   - Added "Profile settings" link to the user dropdown menu
+
+3. **Created timezone utilities** (`apps/web-app/src/lib/timezone.ts`)
+   - `formatDateInTimezone()` - Format dates in user's timezone
+   - `getTimezoneOffset()` - Get human-readable timezone offset
+   - `getBrowserTimezone()` - Detect browser's timezone
+   - `TIMEZONE_OPTIONS` - Common timezone options for dropdowns
+
+## Usage
+
+### For Users
+1. Click on your profile picture in the sidebar
+2. Select "Profile settings" from the dropdown
+3. Choose your timezone from the dropdown list
+4. Click "Save changes"
+
+### For Developers
+To use the user's timezone when displaying dates:
+
+```typescript
+import { formatDateInTimezone } from "@/lib/timezone";
+
+// Format a date in the user's timezone
+const formattedDate = formatDateInTimezone(
+  new Date(), 
+  user.timezone || "UTC",
+  "yyyy-MM-dd HH:mm:ss zzz"
+);
+```
+
+## Migration Instructions
+1. Navigate to the API directory: `cd apps/api`
+2. Run the migration: `bun run migrate`
+
+## Next Steps
+- Update status update displays to show dates in user's timezone
+- Add timezone to user onboarding flow
+- Consider adding automatic timezone detection on signup
+- Add more timezone options if needed

--- a/apps/api/drizzle/0001_natural_rumiko_fujikawa.sql
+++ b/apps/api/drizzle/0001_natural_rumiko_fujikawa.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `user` ADD `timezone` text DEFAULT 'UTC';

--- a/apps/api/drizzle/meta/0001_snapshot.json
+++ b/apps/api/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1860 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4b2dbfa5-2bc6-4173-ab76-e54b6c228aa7",
+  "prevId": "217f11ea-e9c3-45bf-97da-8258160a3d0f",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_account_id_index": {
+          "name": "user_account_id_index",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_event": {
+      "name": "github_event",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_actor_id": {
+          "name": "github_actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repository_id": {
+          "name": "repository_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inserted_at": {
+          "name": "inserted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_event_github_id_unique": {
+          "name": "github_event_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": true
+        },
+        "github_event_repository_id_idx": {
+          "name": "github_event_repository_id_idx",
+          "columns": [
+            "repository_id"
+          ],
+          "isUnique": false
+        },
+        "github_event_created_at_idx": {
+          "name": "github_event_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "github_event_github_id_idx": {
+          "name": "github_event_github_id_idx",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        },
+        "github_event_github_actor_id_idx": {
+          "name": "github_event_github_actor_id_idx",
+          "columns": [
+            "github_actor_id"
+          ],
+          "isUnique": false
+        },
+        "github_event_type_idx": {
+          "name": "github_event_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_event_repository_id_github_repository_id_fk": {
+          "name": "github_event_repository_id_github_repository_id_fk",
+          "tableFrom": "github_event",
+          "tableTo": "github_repository",
+          "columnsFrom": [
+            "repository_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_event_vector": {
+      "name": "github_event_vector",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding_text": {
+          "name": "embedding_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "F32_BLOB(1024)",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_event_vector_event_id_idx": {
+          "name": "github_event_vector_event_id_idx",
+          "columns": [
+            "event_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_event_vector_event_id_github_event_id_fk": {
+          "name": "github_event_vector_event_id_github_event_id_fk",
+          "tableFrom": "github_event_vector",
+          "tableTo": "github_event",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_integration": {
+      "name": "github_integration",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sync_id": {
+          "name": "sync_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status_name": {
+          "name": "sync_status_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_status_step": {
+          "name": "sync_status_step",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_updated_at": {
+          "name": "sync_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_started_at": {
+          "name": "sync_started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_finished_at": {
+          "name": "sync_finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error": {
+          "name": "sync_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sync_error_at": {
+          "name": "sync_error_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_id": {
+          "name": "delete_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_status": {
+          "name": "delete_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "delete_error": {
+          "name": "delete_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_organization_id_index": {
+          "name": "github_organization_id_index",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "github_installation_id_index": {
+          "name": "github_installation_id_index",
+          "columns": [
+            "installation_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_integration_organization_id_organization_id_fk": {
+          "name": "github_integration_organization_id_organization_id_fk",
+          "tableFrom": "github_integration",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_repository": {
+      "name": "github_repository",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repo_id": {
+          "name": "repo_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "full_name": {
+          "name": "full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "private": {
+          "name": "private",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_repository_repo_id_unique": {
+          "name": "github_repository_repo_id_unique",
+          "columns": [
+            "repo_id"
+          ],
+          "isUnique": true
+        },
+        "github_repo_integration_id_index": {
+          "name": "github_repo_integration_id_index",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        },
+        "github_repo_repo_id_index": {
+          "name": "github_repo_repo_id_index",
+          "columns": [
+            "repo_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_repository_integration_id_github_integration_id_fk": {
+          "name": "github_repository_integration_id_github_integration_id_fk",
+          "tableFrom": "github_repository",
+          "tableTo": "github_integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "github_user": {
+      "name": "github_user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "integration_id": {
+          "name": "integration_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "login": {
+          "name": "login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "html_url": {
+          "name": "html_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "github_user_github_id_unique": {
+          "name": "github_user_github_id_unique",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": true
+        },
+        "github_user_integration_id_index": {
+          "name": "github_user_integration_id_index",
+          "columns": [
+            "integration_id"
+          ],
+          "isUnique": false
+        },
+        "github_user_github_id_index": {
+          "name": "github_user_github_id_index",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "github_user_integration_id_github_integration_id_fk": {
+          "name": "github_user_integration_id_github_integration_id_fk",
+          "tableFrom": "github_user",
+          "tableTo": "github_integration",
+          "columnsFrom": [
+            "integration_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitation": {
+      "name": "invitation",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "inviter_id": {
+          "name": "inviter_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_invitation_id_index": {
+          "name": "organization_invitation_id_index",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "inviter_invitation_id_index": {
+          "name": "inviter_invitation_id_index",
+          "columns": [
+            "inviter_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitation_organization_id_organization_id_fk": {
+          "name": "invitation_organization_id_organization_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_team_id_team_id_fk": {
+          "name": "invitation_team_id_team_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invitation_inviter_id_user_id_fk": {
+          "name": "invitation_inviter_id_user_id_fk",
+          "tableFrom": "invitation",
+          "tableTo": "user",
+          "columnsFrom": [
+            "inviter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "member": {
+      "name": "member",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slack_username": {
+          "name": "slack_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_member_id_index": {
+          "name": "organization_member_id_index",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "user_member_id_index": {
+          "name": "user_member_id_index",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "member_github_id_index": {
+          "name": "member_github_id_index",
+          "columns": [
+            "github_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "member_organization_id_organization_id_fk": {
+          "name": "member_organization_id_organization_id_fk",
+          "tableFrom": "member",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_user_id_user_id_fk": {
+          "name": "member_user_id_user_id_fk",
+          "tableFrom": "member",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organization": {
+      "name": "organization",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organization_slug_unique": {
+          "name": "organization_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "slug_index": {
+          "name": "slug_index",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "public_status_share": {
+      "name": "public_status_share",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_update_id": {
+          "name": "status_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "public_status_share_slug_unique": {
+          "name": "public_status_share_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "public_share_status_update_id_index": {
+          "name": "public_share_status_update_id_index",
+          "columns": [
+            "status_update_id"
+          ],
+          "isUnique": false
+        },
+        "public_share_organization_id_index": {
+          "name": "public_share_organization_id_index",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "public_share_slug_index": {
+          "name": "public_share_slug_index",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "public_share_is_active_index": {
+          "name": "public_share_is_active_index",
+          "columns": [
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "public_status_share_status_update_id_status_update_id_fk": {
+          "name": "public_status_share_status_update_id_status_update_id_fk",
+          "tableFrom": "public_status_share",
+          "tableTo": "status_update",
+          "columnsFrom": [
+            "status_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "public_status_share_organization_id_organization_id_fk": {
+          "name": "public_status_share_organization_id_organization_id_fk",
+          "tableFrom": "public_status_share",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "status_generation_job": {
+      "name": "status_generation_job",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_update_id": {
+          "name": "status_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "status_job_member_idx": {
+          "name": "status_job_member_idx",
+          "columns": [
+            "member_id"
+          ],
+          "isUnique": false
+        },
+        "status_job_state_idx": {
+          "name": "status_job_state_idx",
+          "columns": [
+            "state"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_generation_job_member_id_member_id_fk": {
+          "name": "status_generation_job_member_id_member_id_fk",
+          "tableFrom": "status_generation_job",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "status_generation_job_status_update_id_status_update_id_fk": {
+          "name": "status_generation_job_status_update_id_status_update_id_fk",
+          "tableFrom": "status_generation_job",
+          "tableTo": "status_update",
+          "columnsFrom": [
+            "status_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "status_update": {
+      "name": "status_update",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "editor_json": {
+          "name": "editor_json",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "effective_to": {
+          "name": "effective_to",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mood": {
+          "name": "mood",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "status_update_member_id_index": {
+          "name": "status_update_member_id_index",
+          "columns": [
+            "member_id"
+          ],
+          "isUnique": false
+        },
+        "status_update_organization_id_index": {
+          "name": "status_update_organization_id_index",
+          "columns": [
+            "organization_id"
+          ],
+          "isUnique": false
+        },
+        "status_update_team_id_index": {
+          "name": "status_update_team_id_index",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "status_update_created_at_index": {
+          "name": "status_update_created_at_index",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "status_update_effective_from_index": {
+          "name": "status_update_effective_from_index",
+          "columns": [
+            "effective_from"
+          ],
+          "isUnique": false
+        },
+        "status_update_effective_to_index": {
+          "name": "status_update_effective_to_index",
+          "columns": [
+            "effective_to"
+          ],
+          "isUnique": false
+        },
+        "status_update_is_draft_index": {
+          "name": "status_update_is_draft_index",
+          "columns": [
+            "is_draft"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_update_member_id_member_id_fk": {
+          "name": "status_update_member_id_member_id_fk",
+          "tableFrom": "status_update",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "status_update_organization_id_organization_id_fk": {
+          "name": "status_update_organization_id_organization_id_fk",
+          "tableFrom": "status_update",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "status_update_team_id_team_id_fk": {
+          "name": "status_update_team_id_team_id_fk",
+          "tableFrom": "status_update",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "status_update_item": {
+      "name": "status_update_item",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_update_id": {
+          "name": "status_update_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_blocker": {
+          "name": "is_blocker",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_in_progress": {
+          "name": "is_in_progress",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "status_update_item_update_id_index": {
+          "name": "status_update_item_update_id_index",
+          "columns": [
+            "status_update_id"
+          ],
+          "isUnique": false
+        },
+        "status_update_item_blocker_index": {
+          "name": "status_update_item_blocker_index",
+          "columns": [
+            "is_blocker"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "status_update_item_status_update_id_status_update_id_fk": {
+          "name": "status_update_item_status_update_id_status_update_id_fk",
+          "tableFrom": "status_update_item",
+          "tableTo": "status_update",
+          "columnsFrom": [
+            "status_update_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team": {
+      "name": "team",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organization_id": {
+          "name": "organization_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_organization_id_organization_id_fk": {
+          "name": "team_organization_id_organization_id_fk",
+          "tableFrom": "team",
+          "tableTo": "organization",
+          "columnsFrom": [
+            "organization_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_membership": {
+      "name": "team_membership",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "team_members_team_id_index": {
+          "name": "team_members_team_id_index",
+          "columns": [
+            "team_id"
+          ],
+          "isUnique": false
+        },
+        "team_members_member_id_index": {
+          "name": "team_members_member_id_index",
+          "columns": [
+            "member_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "team_membership_team_id_team_id_fk": {
+          "name": "team_membership_team_id_team_id_fk",
+          "tableFrom": "team_membership",
+          "tableTo": "team",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "team_membership_member_id_member_id_fk": {
+          "name": "team_membership_member_id_member_id_fk",
+          "tableFrom": "team_membership",
+          "tableTo": "member",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        },
+        "email_user_index": {
+          "name": "email_user_index",
+          "columns": [
+            "email"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "identifier_verification_index": {
+          "name": "identifier_verification_index",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/api/drizzle/meta/_journal.json
+++ b/apps/api/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1750505385065,
       "tag": "0000_chunky_valkyrie",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1750590211133,
+      "tag": "0001_natural_rumiko_fujikawa",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/api/src/db/schema.ts
+++ b/apps/api/src/db/schema.ts
@@ -37,6 +37,7 @@ export const user = sqliteTable(
     email: text("email").notNull().unique(),
     emailVerified: integer("email_verified", { mode: "boolean" }).notNull(),
     image: text("image"),
+    timezone: text("timezone").default("UTC"),
     createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
     updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
   },

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -26,6 +26,7 @@ import { statusUpdateRouter } from "./routers/organization/statusUpdate";
 import { teamsRouter } from "./routers/organization/teams";
 import { publicStatusShareRouter } from "./routers/publicStatusShare";
 import { slackRouter } from "./routers/slack";
+import { userRouter } from "./routers/user";
 import { waitlistRouter } from "./routers/waitlist";
 
 const app = new Hono<HonoEnv>()
@@ -81,17 +82,18 @@ const app = new Hono<HonoEnv>()
     return next();
   })
   .route("/auth", authRouter)
-  .route("/organization", githubRouter)
-  .route("/organization", organizationRouter)
-  .route("/organization", memberRouter)
-  .route("/organization", teamsRouter)
-  .route("/organization", statusUpdateRouter)
-  .route("/organization", organizationPublicShareRouter)
-  .route("/public-status-share", publicStatusShareRouter)
-  .route("/invitation", invitationRouter)
-  .route("/waitlist", waitlistRouter)
-  .route("/slack", slackRouter)
-  .route("/github/webhooks", githubWebhooksRouter)
+.route("/user", userRouter)
+.route("/organization", githubRouter)
+.route("/organization", organizationRouter)
+.route("/organization", memberRouter)
+.route("/organization", teamsRouter)
+.route("/organization", statusUpdateRouter)
+.route("/organization", organizationPublicShareRouter)
+.route("/public-status-share", publicStatusShareRouter)
+.route("/invitation", invitationRouter)
+.route("/waitlist", waitlistRouter)
+.route("/slack", slackRouter)
+.route("/github/webhooks", githubWebhooksRouter)
   .onError((err, c) => {
     console.error(err);
     if (err instanceof AsyncStatusUnexpectedApiError) {

--- a/apps/api/src/routers/user.ts
+++ b/apps/api/src/routers/user.ts
@@ -1,0 +1,109 @@
+import { Hono } from "hono";
+import { zValidator } from "@hono/zod-validator";
+import { eq } from "drizzle-orm";
+import { generateId } from "better-auth";
+
+import { AsyncStatusUnauthorizedError, AsyncStatusUnexpectedApiError } from "../errors";
+import type { HonoEnvWithSession } from "../lib/env";
+import * as schema from "../db/schema";
+import { zUserProfileUpdate } from "../schema/user";
+
+export const userRouter = new Hono<HonoEnvWithSession>()
+  // Get current user profile
+  .get("/me", async (c) => {
+    const user = await c.var.db.query.user.findFirst({
+      where: eq(schema.user.id, c.var.session.user.id),
+    });
+
+    if (!user) {
+      throw new AsyncStatusUnauthorizedError({
+        message: "User not found",
+      });
+    }
+
+    return c.json(user);
+  })
+  // Update current user profile
+  .patch("/me", zValidator("json", zUserProfileUpdate), async (c) => {
+    const updates = c.req.valid("json");
+    const userId = c.var.session.user.id;
+
+    // Handle image upload if provided
+    if (updates.image instanceof File) {
+      const currentUser = await c.var.db.query.user.findFirst({
+        where: eq(schema.user.id, userId),
+      });
+
+      // Delete old image if exists
+      if (currentUser?.image) {
+        await c.env.PRIVATE_BUCKET.delete(currentUser.image);
+      }
+
+      // Upload new image
+      const image = await c.env.PRIVATE_BUCKET.put(
+        generateId(),
+        updates.image,
+      );
+      if (!image) {
+        throw new AsyncStatusUnexpectedApiError({
+          message: "Failed to upload image",
+        });
+      }
+      (updates as any).image = image.key;
+    } else if (updates.image === null) {
+      // Delete image if set to null
+      const currentUser = await c.var.db.query.user.findFirst({
+        where: eq(schema.user.id, userId),
+      });
+      
+      if (currentUser?.image) {
+        await c.env.PRIVATE_BUCKET.delete(currentUser.image);
+      }
+      (updates as any).image = null;
+    }
+
+    // Update user profile
+    const updatedUser = await c.var.db
+      .update(schema.user)
+      .set({
+        ...updates,
+        updatedAt: new Date(),
+      })
+      .where(eq(schema.user.id, userId))
+      .returning();
+
+    if (!updatedUser || !updatedUser[0]) {
+      throw new AsyncStatusUnexpectedApiError({
+        message: "Failed to update user profile",
+      });
+    }
+
+    return c.json(updatedUser[0]);
+  })
+  // Get list of supported timezones
+  .get("/timezones", async (c) => {
+    // Return a list of common timezones
+    // In a real app, you might want to use a library like moment-timezone
+    const timezones = [
+      { value: "UTC", label: "UTC" },
+      { value: "America/New_York", label: "Eastern Time (US & Canada)" },
+      { value: "America/Chicago", label: "Central Time (US & Canada)" },
+      { value: "America/Denver", label: "Mountain Time (US & Canada)" },
+      { value: "America/Los_Angeles", label: "Pacific Time (US & Canada)" },
+      { value: "America/Anchorage", label: "Alaska" },
+      { value: "America/Honolulu", label: "Hawaii" },
+      { value: "Europe/London", label: "London" },
+      { value: "Europe/Paris", label: "Paris" },
+      { value: "Europe/Berlin", label: "Berlin" },
+      { value: "Europe/Moscow", label: "Moscow" },
+      { value: "Asia/Dubai", label: "Dubai" },
+      { value: "Asia/Kolkata", label: "Mumbai, Kolkata, New Delhi" },
+      { value: "Asia/Shanghai", label: "Beijing, Shanghai" },
+      { value: "Asia/Tokyo", label: "Tokyo" },
+      { value: "Asia/Seoul", label: "Seoul" },
+      { value: "Australia/Sydney", label: "Sydney" },
+      { value: "Pacific/Auckland", label: "Auckland" },
+    ];
+
+    return c.json(timezones);
+  });

--- a/apps/api/src/schema/user.ts
+++ b/apps/api/src/schema/user.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+export const zUserProfileUpdate = z.object({
+  name: z.string().min(1).trim().optional(),
+  timezone: z.string().optional(), // IANA timezone identifier (e.g., "America/New_York")
+  image: z.any().transform((val) => {
+    if (val instanceof File) {
+      return val;
+    }
+    if (typeof val === "string") {
+      return val;
+    }
+    return null;
+  }).optional(),
+}).partial();

--- a/apps/web-app/package.json
+++ b/apps/web-app/package.json
@@ -22,6 +22,7 @@
     "@tanstack/react-query": "5.72.2",
     "@tanstack/react-router": "1.115.3",
     "better-auth": "1.2.5",
+    "date-fns-tz": "3.2.0",
     "dayjs": "1.11.13",
     "hono": "4.7.6",
     "motion": "12.15.0",

--- a/apps/web-app/src/components/user-menu.tsx
+++ b/apps/web-app/src/components/user-menu.tsx
@@ -20,13 +20,13 @@ import {
 } from "@asyncstatus/ui/components/sidebar";
 import { Skeleton } from "@asyncstatus/ui/components/skeleton";
 import { toast } from "@asyncstatus/ui/components/sonner";
-import { ChevronsUpDown, CreditCard, LogOut } from "@asyncstatus/ui/icons";
+import { ChevronsUpDown, CreditCard, LogOut, User } from "@asyncstatus/ui/icons";
 import {
   useMutation,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { useNavigate, useRouter } from "@tanstack/react-router";
+import { Link, useNavigate, useRouter } from "@tanstack/react-router";
 
 import { getFileUrl, getInitials } from "@/lib/utils";
 
@@ -130,6 +130,15 @@ export function UserMenu(props: { organizationSlug: string }) {
             </DropdownMenuLabel>
 
             <DropdownMenuGroup>
+              <DropdownMenuItem asChild>
+                <Link
+                  to="/$organizationSlug/profile"
+                  params={{ organizationSlug: props.organizationSlug }}
+                >
+                  <User />
+                  Profile settings
+                </Link>
+              </DropdownMenuItem>
               <DropdownMenuItem asChild>
                 <a
                   href={import.meta.env.VITE_STRIPE_CUSTOMER_PORTAL}

--- a/apps/web-app/src/lib/timezone.ts
+++ b/apps/web-app/src/lib/timezone.ts
@@ -1,0 +1,59 @@
+import { format, formatInTimeZone } from "date-fns-tz";
+
+/**
+ * Format a date in the user's timezone
+ * @param date - The date to format (in UTC)
+ * @param timezone - The user's timezone (IANA identifier)
+ * @param formatStr - The format string (default: 'yyyy-MM-dd HH:mm:ss')
+ * @returns The formatted date string
+ */
+export function formatDateInTimezone(
+  date: Date | string | number,
+  timezone: string,
+  formatStr: string = "yyyy-MM-dd HH:mm:ss"
+): string {
+  return formatInTimeZone(new Date(date), timezone, formatStr);
+}
+
+/**
+ * Get a human-readable timezone offset
+ * @param timezone - The timezone (IANA identifier)
+ * @returns The offset string (e.g., "UTC+5:30")
+ */
+export function getTimezoneOffset(timezone: string): string {
+  const date = new Date();
+  const offset = formatInTimeZone(date, timezone, "XXX"); // e.g., "+05:30"
+  return `UTC${offset}`;
+}
+
+/**
+ * Common timezone options for select dropdowns
+ */
+export const TIMEZONE_OPTIONS = [
+  { value: "UTC", label: "UTC" },
+  { value: "America/New_York", label: "Eastern Time (US & Canada)" },
+  { value: "America/Chicago", label: "Central Time (US & Canada)" },
+  { value: "America/Denver", label: "Mountain Time (US & Canada)" },
+  { value: "America/Los_Angeles", label: "Pacific Time (US & Canada)" },
+  { value: "America/Anchorage", label: "Alaska" },
+  { value: "America/Honolulu", label: "Hawaii" },
+  { value: "Europe/London", label: "London" },
+  { value: "Europe/Paris", label: "Paris" },
+  { value: "Europe/Berlin", label: "Berlin" },
+  { value: "Europe/Moscow", label: "Moscow" },
+  { value: "Asia/Dubai", label: "Dubai" },
+  { value: "Asia/Kolkata", label: "Mumbai, Kolkata, New Delhi" },
+  { value: "Asia/Shanghai", label: "Beijing, Shanghai" },
+  { value: "Asia/Tokyo", label: "Tokyo" },
+  { value: "Asia/Seoul", label: "Seoul" },
+  { value: "Australia/Sydney", label: "Sydney" },
+  { value: "Pacific/Auckland", label: "Auckland" },
+];
+
+/**
+ * Get the browser's timezone
+ * @returns The browser's timezone (IANA identifier)
+ */
+export function getBrowserTimezone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone;
+}

--- a/apps/web-app/src/routeTree.gen.ts
+++ b/apps/web-app/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as authLayoutResetPasswordImport } from './routes/(auth)/_layout.
 import { Route as authLayoutLoginImport } from './routes/(auth)/_layout.login'
 import { Route as authLayoutForgotPasswordImport } from './routes/(auth)/_layout.forgot-password'
 import { Route as OrganizationSlugLayoutSettingsImport } from './routes/$organizationSlug/_layout.settings'
+import { Route as OrganizationSlugLayoutProfileImport } from './routes/$organizationSlug/_layout.profile'
 import { Route as OrganizationSlugLayoutUsersIndexImport } from './routes/$organizationSlug/_layout.users/index'
 import { Route as OrganizationSlugLayoutTeamsIndexImport } from './routes/$organizationSlug/_layout.teams/index'
 import { Route as OrganizationSlugLayoutStatusUpdateIndexImport } from './routes/$organizationSlug/_layout.status-update/index'
@@ -148,6 +149,13 @@ const OrganizationSlugLayoutSettingsRoute =
     getParentRoute: () => OrganizationSlugLayoutRoute,
   } as any)
 
+const OrganizationSlugLayoutProfileRoute =
+  OrganizationSlugLayoutProfileImport.update({
+    id: '/profile',
+    path: '/profile',
+    getParentRoute: () => OrganizationSlugLayoutRoute,
+  } as any)
+
 const OrganizationSlugLayoutUsersIndexRoute =
   OrganizationSlugLayoutUsersIndexImport.update({
     id: '/users/',
@@ -264,6 +272,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutIndexImport
       parentRoute: typeof LayoutImport
     }
+    '/$organizationSlug/_layout/profile': {
+      id: '/$organizationSlug/_layout/profile'
+      path: '/profile'
+      fullPath: '/$organizationSlug/profile'
+      preLoaderRoute: typeof OrganizationSlugLayoutProfileImport
+      parentRoute: typeof OrganizationSlugLayoutImport
+    }
     '/$organizationSlug/_layout/settings': {
       id: '/$organizationSlug/_layout/settings'
       path: '/settings'
@@ -379,6 +394,7 @@ const LayoutRouteWithChildren =
   LayoutRoute._addFileChildren(LayoutRouteChildren)
 
 interface OrganizationSlugLayoutRouteChildren {
+  OrganizationSlugLayoutProfileRoute: typeof OrganizationSlugLayoutProfileRoute
   OrganizationSlugLayoutSettingsRoute: typeof OrganizationSlugLayoutSettingsRoute
   OrganizationSlugLayoutIndexRoute: typeof OrganizationSlugLayoutIndexRoute
   OrganizationSlugLayoutStatusUpdateStatusUpdateIdRoute: typeof OrganizationSlugLayoutStatusUpdateStatusUpdateIdRoute
@@ -391,6 +407,7 @@ interface OrganizationSlugLayoutRouteChildren {
 
 const OrganizationSlugLayoutRouteChildren: OrganizationSlugLayoutRouteChildren =
   {
+    OrganizationSlugLayoutProfileRoute: OrganizationSlugLayoutProfileRoute,
     OrganizationSlugLayoutSettingsRoute: OrganizationSlugLayoutSettingsRoute,
     OrganizationSlugLayoutIndexRoute: OrganizationSlugLayoutIndexRoute,
     OrganizationSlugLayoutStatusUpdateStatusUpdateIdRoute:
@@ -505,6 +522,7 @@ export interface FileRoutesByFullPath {
   '/': typeof LayoutIndexRoute
   '/create-organization': typeof CreateOrganizationLayoutRouteWithChildren
   '/invitation': typeof InvitationLayoutRouteWithChildren
+  '/$organizationSlug/profile': typeof OrganizationSlugLayoutProfileRoute
   '/$organizationSlug/settings': typeof OrganizationSlugLayoutSettingsRoute
   '/forgot-password': typeof authLayoutForgotPasswordRoute
   '/login': typeof authLayoutLoginRoute
@@ -526,6 +544,7 @@ export interface FileRoutesByTo {
   '/': typeof LayoutIndexRoute
   '/create-organization': typeof CreateOrganizationLayoutIndexRoute
   '/invitation': typeof InvitationLayoutIndexRoute
+  '/$organizationSlug/profile': typeof OrganizationSlugLayoutProfileRoute
   '/$organizationSlug/settings': typeof OrganizationSlugLayoutSettingsRoute
   '/forgot-password': typeof authLayoutForgotPasswordRoute
   '/login': typeof authLayoutLoginRoute
@@ -551,6 +570,7 @@ export interface FileRoutesById {
   '/invitation': typeof InvitationRouteWithChildren
   '/invitation/_layout': typeof InvitationLayoutRouteWithChildren
   '/_layout/': typeof LayoutIndexRoute
+  '/$organizationSlug/_layout/profile': typeof OrganizationSlugLayoutProfileRoute
   '/$organizationSlug/_layout/settings': typeof OrganizationSlugLayoutSettingsRoute
   '/(auth)/_layout/forgot-password': typeof authLayoutForgotPasswordRoute
   '/(auth)/_layout/login': typeof authLayoutLoginRoute
@@ -575,6 +595,7 @@ export interface FileRouteTypes {
     | '/'
     | '/create-organization'
     | '/invitation'
+    | '/$organizationSlug/profile'
     | '/$organizationSlug/settings'
     | '/forgot-password'
     | '/login'
@@ -595,6 +616,7 @@ export interface FileRouteTypes {
     | '/'
     | '/create-organization'
     | '/invitation'
+    | '/$organizationSlug/profile'
     | '/$organizationSlug/settings'
     | '/forgot-password'
     | '/login'
@@ -618,6 +640,7 @@ export interface FileRouteTypes {
     | '/invitation'
     | '/invitation/_layout'
     | '/_layout/'
+    | '/$organizationSlug/_layout/profile'
     | '/$organizationSlug/_layout/settings'
     | '/(auth)/_layout/forgot-password'
     | '/(auth)/_layout/login'
@@ -684,6 +707,7 @@ export const routeTree = rootRoute
       "filePath": "$organizationSlug/_layout.tsx",
       "parent": "/$organizationSlug",
       "children": [
+        "/$organizationSlug/_layout/profile",
         "/$organizationSlug/_layout/settings",
         "/$organizationSlug/_layout/",
         "/$organizationSlug/_layout/status-update/$statusUpdateId",
@@ -739,6 +763,10 @@ export const routeTree = rootRoute
     "/_layout/": {
       "filePath": "_layout.index.tsx",
       "parent": "/_layout"
+    },
+    "/$organizationSlug/_layout/profile": {
+      "filePath": "$organizationSlug/_layout.profile.tsx",
+      "parent": "/$organizationSlug/_layout"
     },
     "/$organizationSlug/_layout/settings": {
       "filePath": "$organizationSlug/_layout.settings.tsx",

--- a/apps/web-app/src/routes/$organizationSlug/_layout.profile.tsx
+++ b/apps/web-app/src/routes/$organizationSlug/_layout.profile.tsx
@@ -1,0 +1,257 @@
+import { useState } from "react";
+import { sessionQueryOptions } from "@/rpc/auth";
+import { getOrganizationQueryOptions } from "@/rpc/organization/organization";
+import { zUserProfileUpdate } from "@asyncstatus/api/schema/user";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbList,
+  BreadcrumbPage,
+} from "@asyncstatus/ui/components/breadcrumb";
+import { Button } from "@asyncstatus/ui/components/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@asyncstatus/ui/components/card";
+import { ImageUpload } from "@asyncstatus/ui/components/image-upload";
+import { Input } from "@asyncstatus/ui/components/input";
+import { Label } from "@asyncstatus/ui/components/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@asyncstatus/ui/components/select";
+import { Separator } from "@asyncstatus/ui/components/separator";
+import { SidebarTrigger } from "@asyncstatus/ui/components/sidebar";
+import { toast } from "@asyncstatus/ui/components/sonner";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import {
+  createFileRoute,
+  useParams,
+} from "@tanstack/react-router";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { getFileUrl } from "@/lib/utils";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/form";
+import { rpc } from "@/rpc/rpc";
+
+// Common timezones list
+const TIMEZONES = [
+  { value: "UTC", label: "UTC" },
+  { value: "America/New_York", label: "Eastern Time (US & Canada)" },
+  { value: "America/Chicago", label: "Central Time (US & Canada)" },
+  { value: "America/Denver", label: "Mountain Time (US & Canada)" },
+  { value: "America/Los_Angeles", label: "Pacific Time (US & Canada)" },
+  { value: "America/Anchorage", label: "Alaska" },
+  { value: "America/Honolulu", label: "Hawaii" },
+  { value: "Europe/London", label: "London" },
+  { value: "Europe/Paris", label: "Paris" },
+  { value: "Europe/Berlin", label: "Berlin" },
+  { value: "Europe/Moscow", label: "Moscow" },
+  { value: "Asia/Dubai", label: "Dubai" },
+  { value: "Asia/Kolkata", label: "Mumbai, Kolkata, New Delhi" },
+  { value: "Asia/Shanghai", label: "Beijing, Shanghai" },
+  { value: "Asia/Tokyo", label: "Tokyo" },
+  { value: "Asia/Seoul", label: "Seoul" },
+  { value: "Australia/Sydney", label: "Sydney" },
+  { value: "Pacific/Auckland", label: "Auckland" },
+];
+
+export const Route = createFileRoute("/$organizationSlug/_layout/profile")({
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const params = useParams({ from: "/$organizationSlug" });
+  const queryClient = useQueryClient();
+  const sessionQuery = useSuspenseQuery(sessionQueryOptions());
+  const organizationQuery = useSuspenseQuery(
+    getOrganizationQueryOptions(params.organizationSlug),
+  );
+
+  // Query to get user profile with timezone
+  const userProfileQuery = useQuery({
+    queryKey: ["user", "profile"],
+    queryFn: async () => {
+      const response = await rpc.user.me.$get();
+      if (!response.ok) {
+        throw new Error("Failed to fetch user profile");
+      }
+      return response.json();
+    },
+  });
+
+  // Mutation to update user profile
+  const updateProfileMutation = useMutation({
+    mutationFn: async (data: z.infer<typeof zUserProfileUpdate>) => {
+      const response = await rpc.user.me.$patch({
+        json: data,
+      });
+      if (!response.ok) {
+        throw new Error("Failed to update profile");
+      }
+      return response.json();
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ["user", "profile"] });
+      queryClient.invalidateQueries({ queryKey: sessionQueryOptions().queryKey });
+      toast.success("Profile updated successfully");
+    },
+    onError: (error) => {
+      toast.error(error.message || "Failed to update profile");
+    },
+  });
+
+  const form = useForm({
+    resolver: zodResolver(zUserProfileUpdate),
+    defaultValues: {
+      name: userProfileQuery.data?.name || sessionQuery.data?.user.name || "",
+      timezone: userProfileQuery.data?.timezone || "UTC",
+      image: userProfileQuery.data?.image || sessionQuery.data?.user.image || null,
+    },
+  });
+
+  // Update form when user profile data is loaded
+  if (userProfileQuery.data && !form.formState.isDirty) {
+    form.reset({
+      name: userProfileQuery.data.name,
+      timezone: userProfileQuery.data.timezone || "UTC",
+      image: userProfileQuery.data.image,
+    });
+  }
+
+  return (
+    <>
+      <header className="flex shrink-0 items-center justify-between gap-2">
+        <div className="flex items-center gap-0">
+          <SidebarTrigger className="-ml-1" />
+          <Separator orientation="vertical" className="mr-2 h-4" />
+          <Breadcrumb>
+            <BreadcrumbList>
+              <BreadcrumbItem>
+                <BreadcrumbPage>Profile</BreadcrumbPage>
+              </BreadcrumbItem>
+            </BreadcrumbList>
+          </Breadcrumb>
+        </div>
+      </header>
+
+      <div className="py-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Personal Settings</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Form {...form}>
+              <form
+                onSubmit={form.handleSubmit((values) => {
+                  updateProfileMutation.mutate(values);
+                })}
+                className="space-y-6"
+              >
+                <FormField
+                  control={form.control}
+                  name="name"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Name</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="timezone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Timezone</FormLabel>
+                      <Select
+                        onValueChange={field.onChange}
+                        defaultValue={field.value}
+                      >
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select your timezone" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {TIMEZONES.map((tz) => (
+                            <SelectItem key={tz.value} value={tz.value}>
+                              {tz.label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="image"
+                  render={({ field }) => {
+                    const value =
+                      typeof field.value === "string"
+                        ? getFileUrl({
+                            param: { idOrSlug: params.organizationSlug },
+                            query: { fileKey: field.value },
+                          })
+                        : field.value;
+
+                    return (
+                      <FormItem>
+                        <FormLabel className="mb-2">Profile Image</FormLabel>
+                        <FormControl>
+                          <ImageUpload
+                            value={value}
+                            onChange={field.onChange}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+
+                <div className="flex gap-2">
+                  <Button
+                    type="submit"
+                    disabled={updateProfileMutation.isPending}
+                  >
+                    Save changes
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => form.reset()}
+                    disabled={!form.formState.isDirty}
+                  >
+                    Cancel
+                  </Button>
+                </div>
+              </form>
+            </Form>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,7 @@
         "@tanstack/react-query": "5.72.2",
         "@tanstack/react-router": "1.115.3",
         "better-auth": "1.2.5",
+        "date-fns-tz": "3.2.0",
         "dayjs": "1.11.13",
         "hono": "4.7.6",
         "motion": "12.15.0",
@@ -1529,6 +1530,8 @@
     "data-view-byte-offset": ["data-view-byte-offset@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "is-data-view": "^1.0.1" } }, "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ=="],
 
     "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
+
+    "date-fns-tz": ["date-fns-tz@3.2.0", "", { "peerDependencies": { "date-fns": "^3.0.0 || ^4.0.0" } }, "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ=="],
 
     "dayjs": ["dayjs@1.11.13", "", {}, "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg=="],
 


### PR DESCRIPTION
A user timezone feature was implemented across the application.

*   **Database Schema**: A `timezone` field was added to the `user` table in `apps/api/src/db/schema.ts`, defaulting to "UTC", to store IANA timezone identifiers. A corresponding migration file, `apps/api/drizzle/0001_natural_rumiko_fujikawa.sql`, was generated.
*   **Backend API**:
    *   A new user router was created in `apps/api/src/routers/user.ts` to manage user profiles.
    *   Endpoints were added for fetching the current user's profile (`GET /user/me`), updating it (including timezone) (`PATCH /user/me`), and retrieving a list of supported timezones (`GET /user/timezones`).
    *   A Zod schema `zUserProfileUpdate` was defined in `apps/api/src/schema/user.ts` for profile validation.
    *   The new user router was integrated into the main API routes in `apps/api/src/index.ts`.
*   **Frontend UI**:
    *   A dedicated profile settings page was created at `apps/web-app/src/routes/$organizationSlug/_layout.profile.tsx`, enabling users to update their name, profile image, and select their timezone via a dropdown.
    *   A "Profile settings" link was added to the user menu in `apps/web-app/src/components/user-menu.tsx`.
    *   Frontend utility functions for timezone formatting and detection were added to `apps/web-app/src/lib/timezone.ts`.