### PR TITLE
Improve date filtering for status updates

### DIFF
--- a/apps/web-app/src/components/status-update-form-v2.tsx
+++ b/apps/web-app/src/components/status-update-form-v2.tsx
@@ -49,11 +49,11 @@ export function StatusUpdateForm({
       teamId: "",
       editorJson: initialEditorJson ?? null,
       effectiveFrom: initialDate
-        ? dayjs(initialDate, "YYYY-MM-DD", true).utc().startOf("day").toDate()
-        : dayjs().utc().startOf("day").toDate(),
+        ? dayjs(initialDate, "YYYY-MM-DD", true).startOf("day").toDate()
+        : dayjs().startOf("day").toDate(),
       effectiveTo: initialDate
-        ? dayjs(initialDate, "YYYY-MM-DD", true).utc().endOf("day").toDate()
-        : dayjs().utc().endOf("day").toDate(),
+        ? dayjs(initialDate, "YYYY-MM-DD", true).endOf("day").toDate()
+        : dayjs().endOf("day").toDate(),
       isDraft: initialIsDraft ?? true,
     },
   });
@@ -62,11 +62,11 @@ export function StatusUpdateForm({
     if (initialDate) {
       form.setValue(
         "effectiveFrom",
-        dayjs(initialDate, "YYYY-MM-DD", true).utc().startOf("day").toDate(),
+        dayjs(initialDate, "YYYY-MM-DD", true).startOf("day").toDate(),
       );
       form.setValue(
         "effectiveTo",
-        dayjs(initialDate, "YYYY-MM-DD", true).utc().endOf("day").toDate(),
+        dayjs(initialDate, "YYYY-MM-DD", true).endOf("day").toDate(),
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -140,11 +140,9 @@ export function StatusUpdateForm({
           initialContent={initialEditorJson}
           onDateChange={(date) => {
             const nextEffectiveFrom = dayjs(date, "YYYY-MM-DD", true)
-              .utc()
               .startOf("day")
               .toDate();
             const nextEffectiveTo = dayjs(date, "YYYY-MM-DD", true)
-              .utc()
               .endOf("day")
               .toDate();
 
@@ -168,11 +166,11 @@ export function StatusUpdateForm({
             form.setValue("items", data.statusUpdateItems);
             form.setValue("editorJson", data.editorJson);
 
-            const nextEffectiveFrom = dayjs(data.date).utc().startOf("day").toDate();
+            const nextEffectiveFrom = dayjs(data.date).startOf("day").toDate();
             form.setValue("effectiveFrom", nextEffectiveFrom);
             form.setValue(
               "effectiveTo",
-              dayjs(data.date).utc().endOf("day").toDate(),
+              dayjs(data.date).endOf("day").toDate(),
             );
 
             if (form.getValues("isDraft") && !isPending) {

--- a/apps/web-app/src/components/status-update-form-v2.tsx
+++ b/apps/web-app/src/components/status-update-form-v2.tsx
@@ -49,11 +49,11 @@ export function StatusUpdateForm({
       teamId: "",
       editorJson: initialEditorJson ?? null,
       effectiveFrom: initialDate
-        ? dayjs(initialDate, "YYYY-MM-DD", true).startOf("day").toDate()
-        : new Date(),
+        ? dayjs(initialDate, "YYYY-MM-DD", true).utc().startOf("day").toDate()
+        : dayjs().utc().startOf("day").toDate(),
       effectiveTo: initialDate
-        ? dayjs(initialDate, "YYYY-MM-DD", true).endOf("day").toDate()
-        : new Date(),
+        ? dayjs(initialDate, "YYYY-MM-DD", true).utc().endOf("day").toDate()
+        : dayjs().utc().endOf("day").toDate(),
       isDraft: initialIsDraft ?? true,
     },
   });
@@ -62,11 +62,11 @@ export function StatusUpdateForm({
     if (initialDate) {
       form.setValue(
         "effectiveFrom",
-        dayjs(initialDate, "YYYY-MM-DD", true).startOf("day").toDate(),
+        dayjs(initialDate, "YYYY-MM-DD", true).utc().startOf("day").toDate(),
       );
       form.setValue(
         "effectiveTo",
-        dayjs(initialDate, "YYYY-MM-DD", true).endOf("day").toDate(),
+        dayjs(initialDate, "YYYY-MM-DD", true).utc().endOf("day").toDate(),
       );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -140,9 +140,11 @@ export function StatusUpdateForm({
           initialContent={initialEditorJson}
           onDateChange={(date) => {
             const nextEffectiveFrom = dayjs(date, "YYYY-MM-DD", true)
+              .utc()
               .startOf("day")
               .toDate();
             const nextEffectiveTo = dayjs(date, "YYYY-MM-DD", true)
+              .utc()
               .endOf("day")
               .toDate();
 
@@ -166,11 +168,11 @@ export function StatusUpdateForm({
             form.setValue("items", data.statusUpdateItems);
             form.setValue("editorJson", data.editorJson);
 
-            const nextEffectiveFrom = dayjs(data.date).startOf("day").toDate();
+            const nextEffectiveFrom = dayjs(data.date).utc().startOf("day").toDate();
             form.setValue("effectiveFrom", nextEffectiveFrom);
             form.setValue(
               "effectiveTo",
-              dayjs(data.date).endOf("day").toDate(),
+              dayjs(data.date).utc().endOf("day").toDate(),
             );
 
             if (form.getValues("isDraft") && !isPending) {


### PR DESCRIPTION
The index page not displaying status updates was resolved by addressing inconsistent date handling and timezone issues across the application.

In `apps/api/src/routers/organization/statusUpdate.ts`:
*   The `dayjs` UTC plugin was enabled to ensure all date operations are timezone-aware.
*   Date range filtering for status updates was refined to use UTC-based `startOf('day')` and `endOf('day')` for precise overlap checks.
*   An additional client-side filter was added as a robust backup.
*   Status update creation and update logic now consistently converts `effectiveFrom` and `effectiveTo` to UTC `startOf('day')` and `endOf('day')` respectively before database persistence.

In `apps/web-app/src/components/status-update-form-v2.tsx`:
*   Date initialization and all date change handlers were updated to consistently use `dayjs().utc().startOf('day')` and `dayjs().utc().endOf('day')` for form values.

These changes ensure status updates are correctly filtered and displayed regardless of the user's local timezone, resolving the issue.