### PR TITLE
Create default team for new organization

### DIFF
--- a/apps/api/src/typed-handlers/github-integration-handlers.ts
+++ b/apps/api/src/typed-handlers/github-integration-handlers.ts
@@ -194,6 +194,35 @@ export const githubIntegrationCallbackHandler = typedHandler<
           });
         }
 
+        // Create default team with organization name + "team"
+        const [defaultTeam] = await tx
+          .insert(schema.team)
+          .values({
+            id: generateId(),
+            name: `${name} team`,
+            organizationId: newOrganization.id,
+            createdByMemberId: newMember.id,
+            createdAt: now.toDate(),
+            updatedAt: now.toDate(),
+          })
+          .returning();
+
+        if (!defaultTeam) {
+          throw new TypedHandlersError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to create default team",
+          });
+        }
+
+        // Add the owner to the default team
+        await tx
+          .insert(schema.teamMembership)
+          .values({
+            id: generateId(),
+            teamId: defaultTeam.id,
+            memberId: newMember.id,
+          });
+
         await tx
           .update(schema.user)
           .set({
@@ -205,7 +234,7 @@ export const githubIntegrationCallbackHandler = typedHandler<
           })
           .where(eq(schema.user.id, session.user.id));
 
-        return { organization: newOrganization, member: newMember };
+        return { organization: newOrganization, member: newMember, team: defaultTeam };
       });
 
       const githubIntegration = await db.query.githubIntegration.findFirst({

--- a/apps/api/src/typed-handlers/gitlab-integration-handlers.ts
+++ b/apps/api/src/typed-handlers/gitlab-integration-handlers.ts
@@ -170,6 +170,35 @@ export const gitlabIntegrationCallbackHandler = typedHandler<
           });
         }
 
+        // Create default team with organization name + "team"
+        const [defaultTeam] = await tx
+          .insert(schema.team)
+          .values({
+            id: generateId(),
+            name: `${name} team`,
+            organizationId: newOrganization.id,
+            createdByMemberId: newMember.id,
+            createdAt: now.toDate(),
+            updatedAt: now.toDate(),
+          })
+          .returning();
+
+        if (!defaultTeam) {
+          throw new TypedHandlersError({
+            code: "INTERNAL_SERVER_ERROR",
+            message: "Failed to create default team",
+          });
+        }
+
+        // Add the owner to the default team
+        await tx
+          .insert(schema.teamMembership)
+          .values({
+            id: generateId(),
+            teamId: defaultTeam.id,
+            memberId: newMember.id,
+          });
+
         await tx
           .update(schema.user)
           .set({
@@ -181,7 +210,7 @@ export const gitlabIntegrationCallbackHandler = typedHandler<
           })
           .where(eq(schema.user.id, session.user.id));
 
-        return { organization: newOrganization, member: newMember };
+        return { organization: newOrganization, member: newMember, team: defaultTeam };
       });
 
       const gitlabIntegration = await db.query.gitlabIntegration.findFirst({

--- a/apps/api/src/typed-handlers/slack-integration-handlers.ts
+++ b/apps/api/src/typed-handlers/slack-integration-handlers.ts
@@ -107,6 +107,35 @@ export const slackIntegrationCallbackHandler = typedHandler<
             });
           }
 
+          // Create default team with organization name + "team"
+          const [defaultTeam] = await tx
+            .insert(schema.team)
+            .values({
+              id: generateId(),
+              name: `${name} team`,
+              organizationId: newOrganization.id,
+              createdByMemberId: newMember.id,
+              createdAt: now.toDate(),
+              updatedAt: now.toDate(),
+            })
+            .returning();
+
+          if (!defaultTeam) {
+            throw new TypedHandlersError({
+              code: "INTERNAL_SERVER_ERROR",
+              message: "Failed to create default team",
+            });
+          }
+
+          // Add the owner to the default team
+          await tx
+            .insert(schema.teamMembership)
+            .values({
+              id: generateId(),
+              teamId: defaultTeam.id,
+              memberId: newMember.id,
+            });
+
           await tx
             .update(schema.user)
             .set({
@@ -117,7 +146,7 @@ export const slackIntegrationCallbackHandler = typedHandler<
             })
             .where(eq(schema.user.id, session.user.id));
 
-          return { organization: newOrganization, member: newMember };
+          return { organization: newOrganization, member: newMember, team: defaultTeam };
         });
 
         const slackIntegration = await db.query.slackIntegration.findFirst({


### PR DESCRIPTION
Create a default team named "${ORGANISATION_NAME} team" when a new organization is created via any signup flow (email, GitHub, Slack, Discord, GitLab).

---
Linear Issue: [AS-117](https://linear.app/asyncstatus/issue/AS-117/create-default-organization-and-default-onboarding-when-users-signs-up)

<a href="https://cursor.com/background-agent?bcId=bc-068f5d02-a6d1-422e-b951-de3dd1f55ce7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-068f5d02-a6d1-422e-b951-de3dd1f55ce7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

