### PR TITLE
Prevent empty notifications and add UI option

### DIFF
--- a/apps/web-app/src/components/update-schedule-form/action-form-content.tsx
+++ b/apps/web-app/src/components/update-schedule-form/action-form-content.tsx
@@ -6,6 +6,8 @@ import type {
   updateScheduleContract,
 } from "@asyncstatus/api/typed-handlers/schedule";
 import { Button } from "@asyncstatus/ui/components/button";
+import { Checkbox } from "@asyncstatus/ui/components/checkbox";
+import { Label } from "@asyncstatus/ui/components/label";
 import {
   Select,
   SelectContent,
@@ -178,6 +180,28 @@ export function ActionFormContent(props: ActionFormContentProps) {
         )}
       </div>
 
+      {configName === "sendSummaries" && (
+        <FormField
+          control={form.control}
+          name="config.skipEmptyNotifications"
+          render={({ field }) => (
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="skip-empty-notifications"
+                checked={field.value ?? true}
+                onCheckedChange={field.onChange}
+              />
+              <Label
+                htmlFor="skip-empty-notifications"
+                className="text-sm font-normal text-muted-foreground cursor-pointer"
+              >
+                Skip sending notification if no updates or activity found
+              </Label>
+            </div>
+          )}
+        />
+      )}
+
       {!isAddingGenerateFor && (
         <FormField
           control={form.control}
@@ -255,6 +279,10 @@ function getDefaultConfigBasedOnName(
           previousConfig?.name === "remindToPostUpdates" || previousConfig?.name === "sendSummaries"
             ? previousConfig?.deliveryMethods
             : [{ type: "organization", value: organizationSlug }],
+        skipEmptyNotifications:
+          previousConfig?.name === "sendSummaries"
+            ? previousConfig?.skipEmptyNotifications ?? true
+            : true,
       } satisfies ScheduleConfigSendSummaries;
   }
 }

--- a/packages/db/src/schedule-config-schema.ts
+++ b/packages/db/src/schedule-config-schema.ts
@@ -199,6 +199,7 @@ export const ScheduleConfigSendSummaries = z.strictObject({
   dayOfMonth: z.number().min(1).max(28).optional(), // 1-28 for monthly
   summaryFor: z.array(ScheduleConfigSummaryFor.or(z.undefined())),
   deliveryMethods: z.array(ScheduleConfigDeliveryMethod.or(z.undefined())),
+  skipEmptyNotifications: z.boolean().default(true), // Skip sending if no data/updates found
 });
 export type ScheduleConfigSendSummaries = z.infer<typeof ScheduleConfigSendSummaries>;
 
@@ -574,6 +575,10 @@ export const ScheduleConfigSendSummariesV3 = z3
       .array(ScheduleConfigDeliveryMethodV3)
       .default([])
       .describe("Where summaries should be delivered (email, Slack, Discord, etc.)"),
+    skipEmptyNotifications: z3
+      .boolean()
+      .default(true)
+      .describe("Skip sending notifications if no data/updates are found"),
   })
   .strict()
   .describe("Configuration for sending team summaries");


### PR DESCRIPTION
Add an option to skip sending summary notifications if no updates or activity are found, to prevent empty messages.

---
Linear Issue: [AS-159](https://linear.app/asyncstatus/issue/AS-159/add-the-option-to-do-not-send-notification-without-any-update-if-there)

<a href="https://cursor.com/background-agent?bcId=bc-b3f9feca-c0f1-4cde-bc19-f6619b50ea10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3f9feca-c0f1-4cde-bc19-f6619b50ea10"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

